### PR TITLE
Added caching to CurrencyExchangeService with 4 minute eviction policy.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,32 @@ docker run -p 8081:8080 paidyinc/one-frame
 ./gradlew bootRun
 ```
 
+### Run the tests
+```bash
+./gradlew test --tests "com.example.*Unit*"
+```
+
+### Run integration tests
+Ensure the environment is up and running. Then, run the following command.
+```bash
+./gradlew test --tests "com.example.*Integration*"
+```
+
+### Run the bash script which makes 10000 requests to the api
+```bash
+./test.sh
+```
+
 ## Design Considerations
 I kept this pretty minimal and focused on the main requirements. There's simple validation, error handling, and unit tests.
 I am also new to Spring Boot, so there are probably better ways to do things. Nevertheless, it was a fun project to work on.
 The paidy container has a 1000 request limit, so we need to cache the exchange rates. I added a basic cache evicting after 4 minutes.
 This enables fresh enough exchange rates and enabling over 10000 requests per day.
-There's a bash script that can be used to make 10000 requests to the api. It's not perfect, but works for now. With more time,
-I'd investigate how to utilize Spring Boot and write a test that meets this requirement. 
+There's a bash script that can be used to make 10000 requests to the api. It's not perfect, but works for now.
+I added a simple integration test for the service to ensure the cache is used as expected. The cache usage
+should guarantee fresh exchange rates are fetched. A heavy assumption here is that the paidy container always returns fresh values.
+
+With more time, I'd like to add more tests and improve existing ones.
 
 
 ## If this were a real project

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ docker run -p 8081:8080 paidyinc/one-frame
 ## Design Considerations
 I kept this pretty minimal and focused on the main requirements. There's simple validation, error handling, and unit tests.
 I am also new to Spring Boot, so there are probably better ways to do things. Nevertheless, it was a fun project to work on.
+The paidy container has a 1000 request limit, so we need to cache the exchange rates. I added a basic cache evicting after 4 minutes.
+This enables fresh enough exchange rates and enabling over 10000 requests per day.
+There's a bash script that can be used to make 10000 requests to the api. It's not perfect, but works for now. With more time,
+I'd investigate how to utilize Spring Boot and write a test that meets this requirement. 
+
 
 ## If this were a real project
 For an MVP, it needs to be useful enough for the client. We can continuously iterate on the MVP to make it more useful.
@@ -42,14 +47,12 @@ Production-ready means the service has sufficient reliability, performance, and 
 - Runbook exists to ensure smooth on-call experience
 
 ### Regarding the api
-- The api can handle more than 2 currencies. For simplicity, the service making the api call will only support 2 currencies.
 - If the api is not working, should the user get an old value or an error?
     - If old value, should we let them know it's old?
 - If the api is too flaky, maybe a separate job can deal with collecting fresh exchange rates and persist it in our cache or db.
     - The cheapest solution is probably just an in-memory cache.
         - 5 instances with their own in-memory cache could lead to inconsistency
             - If that's important, we should probably have a centralized database storing the exchange rates.
-- If the api is prone to hitting rate limits, caching is a good solution.
 
 ### Response models
 - JSON responses with minimal customization

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,10 @@ dependencies {
 	//web client
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+	//cache
+	implementation("org.springframework.boot:spring-boot-starter-cache")
+
 	//square okhttp3
 	testImplementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
 	testImplementation("com.squareup.okhttp3:okhttp")

--- a/src/main/java/com/example/forexproxy/config/CacheConfig.java
+++ b/src/main/java/com/example/forexproxy/config/CacheConfig.java
@@ -1,0 +1,29 @@
+package com.example.forexproxy.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import static javax.management.timer.Timer.ONE_MINUTE;
+
+@EnableCaching
+@EnableScheduling
+@Configuration
+public class CacheConfig {
+
+    public static final String CACHE_NAME = "exchangeRates";
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(CACHE_NAME);
+    }
+
+    @Scheduled(fixedRate = ONE_MINUTE * 4)
+    public void evictCache() {
+        cacheManager().getCache(CACHE_NAME).clear();
+    }
+}

--- a/src/main/java/com/example/forexproxy/config/CacheConfig.java
+++ b/src/main/java/com/example/forexproxy/config/CacheConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
-import static javax.management.timer.Timer.ONE_MINUTE;
 
 @EnableCaching
 @EnableScheduling
@@ -22,7 +21,7 @@ public class CacheConfig {
         return new ConcurrentMapCacheManager(CACHE_NAME);
     }
 
-    @Scheduled(fixedRate = ONE_MINUTE * 4)
+    @Scheduled(fixedRateString = "${currency.exchange.service.cache.evictionTime}")
     public void evictCache() {
         cacheManager().getCache(CACHE_NAME).clear();
     }

--- a/src/main/java/com/example/forexproxy/config/Configuration.java
+++ b/src/main/java/com/example/forexproxy/config/Configuration.java
@@ -1,0 +1,10 @@
+package com.example.forexproxy.config;
+
+import java.util.Set;
+
+public class Configuration {
+    //TODO: Read from config file
+    public static final Set<String> ALLOWED_CURRENCIES = Set.of("AUD", "CAD", "CHF", "EUR", "GBP", "NZD", "JPY", "SGD", "USD");
+    //TODO: Calculate this value
+    public static final int ALLOWED_CURRENCIES_PAIR_COUNT = 36;
+}

--- a/src/main/java/com/example/forexproxy/models/Currency.java
+++ b/src/main/java/com/example/forexproxy/models/Currency.java
@@ -9,7 +9,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.Set;
+
+import static com.example.forexproxy.config.Configuration.ALLOWED_CURRENCIES;
 
 @Target({ElementType.FIELD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
@@ -21,7 +22,6 @@ public @interface Currency {
 }
 
 class CurrencyValidator implements ConstraintValidator<Currency, String> {
-    private static final Set<String> ALLOWED_CURRENCIES = Set.of("AUD", "CAD", "CHF", "EUR", "GBP", "NZD", "JPY", "SGD", "USD");
 
     @Override
     public boolean isValid(String currency, ConstraintValidatorContext context) {

--- a/src/main/java/com/example/forexproxy/services/CurrencyExchangeService.java
+++ b/src/main/java/com/example/forexproxy/services/CurrencyExchangeService.java
@@ -1,116 +1,26 @@
 package com.example.forexproxy.services;
 
-import com.example.forexproxy.services.models.CurrencyExchangeServiceError;
+import com.example.forexproxy.services.clients.ForexProxyClient;
 import com.example.forexproxy.services.models.ExchangeRate;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.util.UriComponentsBuilder;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.example.forexproxy.config.Configuration.ALLOWED_CURRENCIES;
-import static com.example.forexproxy.config.Configuration.ALLOWED_CURRENCIES_PAIR_COUNT;
 
 @Service
 public class CurrencyExchangeService {
-    private String baseUri;
-    private String token;
-    private WebClient webClient;
 
-    public CurrencyExchangeService(
-            @Value("${currency.exchange.service.uri}") String baseUri,
-            @Value("${currency.exchange.service.token}") String token
-    ) {
-        this.baseUri = baseUri;
-        this.token = token;
-        this.webClient = WebClient.builder()
-                .baseUrl(this.baseUri)
-                .defaultCookie("cookieKey", "cookieValue")
-                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .defaultHeader("token", this.token)
-                .build();
+    @Autowired
+    private ForexProxyClient client;
+
+    public CurrencyExchangeService(ForexProxyClient client) {
+        this.client = client;
     }
 
-    public List<ExchangeRate> getExchangeRate(String fromCurrency, String toCurrency) {
-        List<ExchangeRate> response = webClient.get()
-                .uri("/rates?pair={currency_pair_0}", fromCurrency + toCurrency)
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, resp -> {
-                    Mono<String> responseBodyMono = resp.bodyToMono(String.class);
-                    return responseBodyMono.flatMap(responseBody -> {
-                        String errorMessage = "CurrencyExchangeServiceError Client error: " + responseBody;
-                        return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
-                    });
-                })
-                .onStatus(HttpStatusCode::is5xxServerError, resp -> {
-                    Mono<String> responseBodyMono = resp.bodyToMono(String.class);
-                    return responseBodyMono.flatMap(responseBody -> {
-                        String errorMessage = "CurrencyExchangeServiceError Server error: " + responseBody;
-                        return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
-                    });
-                })
-                .bodyToFlux(ExchangeRate.class)
-                .collectList()
-                .block();
-        return response;
-    }
-
-    @Cacheable("exchangeRates")
+    @Cacheable(value = "exchangeRates", key = "'exchangeRatesKey'")
     public List<ExchangeRate> getAllExchangeRates() {
-        String queryParams = ALLOWED_CURRENCIES.stream()
-                .flatMap(c1 -> ALLOWED_CURRENCIES.stream()
-                        .filter(c2 -> c2.compareTo(c1) > 0)
-                        .map(c2 -> "pair=" + c1 + c2))
-                .collect(Collectors.joining("&"));
-
-        String uri = UriComponentsBuilder
-                .fromPath("rates")
-                .query(queryParams)
-                .build()
-                .encode()
-                .toUriString();
-        try {
-            List<ExchangeRate> response = webClient.get()
-                    .uri(uri)
-                    .retrieve()
-                    .onStatus(HttpStatusCode::is4xxClientError, resp -> {
-                        Mono<String> responseBodyMono = resp.bodyToMono(String.class);
-                        return responseBodyMono.flatMap(responseBody -> {
-                            String errorMessage = "CurrencyExchangeServiceError Client error: " + responseBody;
-                            return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
-                        });
-                    })
-                    .onStatus(HttpStatusCode::is5xxServerError, resp -> {
-                        Mono<String> responseBodyMono = resp.bodyToMono(String.class);
-                        return responseBodyMono.flatMap(responseBody -> {
-                            String errorMessage = "CurrencyExchangeServiceError Server error: " + responseBody;
-                            return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
-                        });
-                    })
-                    .bodyToFlux(ExchangeRate.class)
-                    .collectList()
-                    .block();
-            if (response.size() != ALLOWED_CURRENCIES_PAIR_COUNT) {
-                String errorMessage = "CurrencyExchangeServiceError Server error: " + "Invalid response from currency exchange service";
-                throw new CurrencyExchangeServiceError(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
-            }
-            return response;
-        }
-        catch (CurrencyExchangeServiceError e){
-            throw e;
-        }
-        catch (Exception e) {
-            String errorMessage = "CurrencyExchangeServiceError Unknown error: " + e.getMessage();
-            throw new CurrencyExchangeServiceError(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        return client.getAllExchangeRates();
     }
 }
 

--- a/src/main/java/com/example/forexproxy/services/CurrencyExchangeService.java
+++ b/src/main/java/com/example/forexproxy/services/CurrencyExchangeService.java
@@ -3,21 +3,28 @@ package com.example.forexproxy.services;
 import com.example.forexproxy.services.models.CurrencyExchangeServiceError;
 import com.example.forexproxy.services.models.ExchangeRate;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.forexproxy.config.Configuration.ALLOWED_CURRENCIES;
+import static com.example.forexproxy.config.Configuration.ALLOWED_CURRENCIES_PAIR_COUNT;
 
 @Service
 public class CurrencyExchangeService {
     private String baseUri;
     private String token;
     private WebClient webClient;
-    // TODO: Add caching if api is too flaky
+
     public CurrencyExchangeService(
             @Value("${currency.exchange.service.uri}") String baseUri,
             @Value("${currency.exchange.service.token}") String token
@@ -54,6 +61,56 @@ public class CurrencyExchangeService {
                 .collectList()
                 .block();
         return response;
+    }
+
+    @Cacheable("exchangeRates")
+    public List<ExchangeRate> getAllExchangeRates() {
+        String queryParams = ALLOWED_CURRENCIES.stream()
+                .flatMap(c1 -> ALLOWED_CURRENCIES.stream()
+                        .filter(c2 -> c2.compareTo(c1) > 0)
+                        .map(c2 -> "pair=" + c1 + c2))
+                .collect(Collectors.joining("&"));
+
+        String uri = UriComponentsBuilder
+                .fromPath("rates")
+                .query(queryParams)
+                .build()
+                .encode()
+                .toUriString();
+        try {
+            List<ExchangeRate> response = webClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, resp -> {
+                        Mono<String> responseBodyMono = resp.bodyToMono(String.class);
+                        return responseBodyMono.flatMap(responseBody -> {
+                            String errorMessage = "CurrencyExchangeServiceError Client error: " + responseBody;
+                            return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
+                        });
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, resp -> {
+                        Mono<String> responseBodyMono = resp.bodyToMono(String.class);
+                        return responseBodyMono.flatMap(responseBody -> {
+                            String errorMessage = "CurrencyExchangeServiceError Server error: " + responseBody;
+                            return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
+                        });
+                    })
+                    .bodyToFlux(ExchangeRate.class)
+                    .collectList()
+                    .block();
+            if (response.size() != ALLOWED_CURRENCIES_PAIR_COUNT) {
+                String errorMessage = "CurrencyExchangeServiceError Server error: " + "Invalid response from currency exchange service";
+                throw new CurrencyExchangeServiceError(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+            return response;
+        }
+        catch (CurrencyExchangeServiceError e){
+            throw e;
+        }
+        catch (Exception e) {
+            String errorMessage = "CurrencyExchangeServiceError Unknown error: " + e.getMessage();
+            throw new CurrencyExchangeServiceError(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }
 

--- a/src/main/java/com/example/forexproxy/services/clients/ForexProxyClient.java
+++ b/src/main/java/com/example/forexproxy/services/clients/ForexProxyClient.java
@@ -1,0 +1,10 @@
+package com.example.forexproxy.services.clients;
+
+import com.example.forexproxy.services.models.ExchangeRate;
+
+import java.util.List;
+
+public interface ForexProxyClient {
+    List<ExchangeRate> getAllExchangeRates();
+
+}

--- a/src/main/java/com/example/forexproxy/services/clients/PaidyForexProxyClient.java
+++ b/src/main/java/com/example/forexproxy/services/clients/PaidyForexProxyClient.java
@@ -1,0 +1,90 @@
+package com.example.forexproxy.services.clients;
+
+import com.example.forexproxy.services.models.CurrencyExchangeServiceError;
+import com.example.forexproxy.services.models.ExchangeRate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.forexproxy.config.Configuration.ALLOWED_CURRENCIES;
+import static com.example.forexproxy.config.Configuration.ALLOWED_CURRENCIES_PAIR_COUNT;
+
+@Component
+public class PaidyForexProxyClient implements ForexProxyClient {
+    private String baseUri;
+    private String token;
+    private WebClient webClient;
+
+    public PaidyForexProxyClient(
+            @Value("${currency.exchange.service.uri}") String baseUri,
+            @Value("${currency.exchange.service.token}") String token
+    ) {
+        this.baseUri = baseUri;
+        this.token = token;
+        this.webClient = WebClient.builder()
+                .baseUrl(this.baseUri)
+                .defaultCookie("cookieKey", "cookieValue")
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .defaultHeader("token", this.token)
+                .build();
+    }
+
+    public List<ExchangeRate> getAllExchangeRates() {
+        String queryParams = ALLOWED_CURRENCIES.stream()
+                .flatMap(c1 -> ALLOWED_CURRENCIES.stream()
+                        .filter(c2 -> c2.compareTo(c1) > 0)
+                        .map(c2 -> "pair=" + c1 + c2))
+                .collect(Collectors.joining("&"));
+
+        String uri = UriComponentsBuilder
+                .fromPath("rates")
+                .query(queryParams)
+                .build()
+                .encode()
+                .toUriString();
+        try {
+            List<ExchangeRate> response = webClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, resp -> {
+                        Mono<String> responseBodyMono = resp.bodyToMono(String.class);
+                        return responseBodyMono.flatMap(responseBody -> {
+                            String errorMessage = "CurrencyExchangeServiceError Client error: " + responseBody;
+                            return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
+                        });
+                    })
+                    .onStatus(HttpStatusCode::is5xxServerError, resp -> {
+                        Mono<String> responseBodyMono = resp.bodyToMono(String.class);
+                        return responseBodyMono.flatMap(responseBody -> {
+                            String errorMessage = "CurrencyExchangeServiceError Server error: " + responseBody;
+                            return Mono.error(new CurrencyExchangeServiceError(errorMessage, resp.statusCode()));
+                        });
+                    })
+                    .bodyToFlux(ExchangeRate.class)
+                    .collectList()
+                    .block();
+            if (response.size() != ALLOWED_CURRENCIES_PAIR_COUNT) {
+                String errorMessage = "CurrencyExchangeServiceError Server error: " + "Invalid response from currency exchange service";
+                throw new CurrencyExchangeServiceError(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+            return response;
+        }
+        catch (CurrencyExchangeServiceError e){
+            throw e;
+        }
+        catch (Exception e) {
+            String errorMessage = "CurrencyExchangeServiceError Unknown error: " + e.getMessage();
+            throw new CurrencyExchangeServiceError(errorMessage, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}

--- a/src/test/java/com/example/forexproxy/controllers/CurrencyExchangeControllerTest.java
+++ b/src/test/java/com/example/forexproxy/controllers/CurrencyExchangeControllerTest.java
@@ -43,7 +43,7 @@ class CurrencyExchangeControllerTest {
     @ParameterizedTest(name = "Exchange rate between {0} and {1}")
     @MethodSource("generateCurrencyPairs")
     void whenValidInput_thenReturns200WithJson(String input1, String input2) throws Exception {
-        when(currencyExchangeService.getExchangeRate(input1, input2)).thenReturn(List.of(new ExchangeRate(input1, input2, 1.0, 1.0, 1.0,"")));
+        when(currencyExchangeService.getAllExchangeRates()).thenReturn(List.of(new ExchangeRate(input1, input2, 1.0, 1.0, 1.0,"")));
         mockMvc.perform(get("/api/exchange-rates?fromCurrency={input1}&toCurrency={input2}", input1, input2))
                 .andExpect(status().isOk())
                 .andExpect(result -> {
@@ -57,7 +57,7 @@ class CurrencyExchangeControllerTest {
     void whenInvalidInput_thenReturns400WithJson() throws Exception {
         String input1 = "USD";
         String input2 = "BADBADNOTGOOD";
-        when(currencyExchangeService.getExchangeRate(input1, input2)).thenReturn(List.of(new ExchangeRate(input1, input2, 1.0, 1.0, 1.0,"")));
+        when(currencyExchangeService.getAllExchangeRates()).thenReturn(List.of(new ExchangeRate(input1, input2, 1.0, 1.0, 1.0,"")));
         mockMvc.perform(get("/api/exchange-rates?fromCurrency={input1}&toCurrency={input2}", input1, input2))
                 .andExpect(status().isBadRequest())
                 .andExpect(result -> {
@@ -71,7 +71,7 @@ class CurrencyExchangeControllerTest {
     void whenException_thenReturns500WithJson() throws Exception {
         String input1 = "USD";
         String input2 = "CAD";
-        when(currencyExchangeService.getExchangeRate(input1, input2)).thenThrow(new RuntimeException());
+        when(currencyExchangeService.getAllExchangeRates()).thenThrow(new RuntimeException());
         mockMvc.perform(get("/api/exchange-rates?fromCurrency={input1}&toCurrency={input2}", input1, input2))
                 .andExpect(status().isInternalServerError())
                 .andExpect(result -> {

--- a/src/test/java/com/example/forexproxy/services/CurrencyExchangeServiceIntegrationTest.java
+++ b/src/test/java/com/example/forexproxy/services/CurrencyExchangeServiceIntegrationTest.java
@@ -1,0 +1,67 @@
+package com.example.forexproxy.services;
+
+import com.example.forexproxy.ForexProxyApplication;
+import com.example.forexproxy.services.models.ExchangeRate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Description;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ForexProxyApplication.class)
+public class CurrencyExchangeServiceIntegrationTest {
+
+    @Autowired
+    private CurrencyExchangeService service;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    public void setup() {
+        cacheManager.getCache("exchangeRates").clear();
+    }
+
+    @Test
+    public void verifyCacheIsUsed() {
+        assertTrue(getCachedExchangeRates().isEmpty());
+        service.getAllExchangeRates();
+
+        assertFalse(getCachedExchangeRates().isEmpty());
+        service.getAllExchangeRates();
+    }
+
+    @Test
+    @Description("Verify the cache is evicted after the configured time")
+    public void verifyCacheIsEvicted() throws InterruptedException {
+        assertTrue(getCachedExchangeRates().isEmpty());
+        service.getAllExchangeRates();
+        assertFalse(getCachedExchangeRates().isEmpty());
+        Thread.sleep(1000);
+        assertTrue(getCachedExchangeRates().isEmpty());
+    }
+
+    private List<ExchangeRate> getCachedExchangeRates() {
+        Cache cache = cacheManager.getCache("exchangeRates");
+        try {
+            List<ExchangeRate> cachedExchangeRates = cache.get("exchangeRatesKey", List.class);
+            if (cachedExchangeRates == null) {
+                return List.of();
+            } else {
+                return cachedExchangeRates;
+            }
+        } catch (NullPointerException e) {
+            return List.of();
+        }
+    }
+}

--- a/src/test/java/com/example/forexproxy/services/PaidyForexProxyClientTest.java
+++ b/src/test/java/com/example/forexproxy/services/PaidyForexProxyClientTest.java
@@ -1,7 +1,9 @@
 package com.example.forexproxy.services;
 
+import com.example.forexproxy.services.clients.PaidyForexProxyClient;
 import com.example.forexproxy.services.models.CurrencyExchangeServiceError;
 import com.example.forexproxy.services.models.ExchangeRate;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,44 +12,43 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-class CurrencyExchangeServiceTest {
+class PaidyForexProxyClientTest {
 
     private MockWebServer mockWebServer;
-    private CurrencyExchangeService currencyExchangeService;
+    private PaidyForexProxyClient client;
 
     @BeforeEach
     void setUp() throws IOException {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
         String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
-        currencyExchangeService = new CurrencyExchangeService(baseUrl, "test-token");
+        client = new PaidyForexProxyClient(baseUrl, "test-token");
     }
 
     @Test
     void getExchangeRate_returnsExpectedResponse() {
-        String mockResponseBody = """
-                [
-                    {
-                        "from": "USD",
-                        "to": "EUR",
-                        "bid": 0.81281,
-                        "ask": 0.81281,
-                        "price": 0.81281,
-                        "timestamp": "2023-03-23T00:00:00Z"              
-                    }
-                ]""".replaceAll("\\s", "");
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<ExchangeRate> expectedResponse = new ArrayList<>();
+        ExchangeRate fakeRate = new ExchangeRate("USD", "EUR", 0.81281,0.81281,0.81281,"2023-03-23T00:00:00Z");
+        int supportedCurrencyCount = 36;
+        for (int i = 0; i < supportedCurrencyCount; i++) {
+            expectedResponse.add(fakeRate);
+        }
+        String mockResponseBody = objectMapper.valueToTree(expectedResponse).toString();
+
         mockWebServer.enqueue(new MockResponse()
                 .setBody(mockResponseBody)
                 .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE));
 
-        List<ExchangeRate> response = currencyExchangeService.getExchangeRate("USD", "EUR");
+        List<ExchangeRate> response = client.getAllExchangeRates();
 
-        assertEquals(1, response.size());
+        assertEquals(supportedCurrencyCount, response.size());
         assertEquals("USD", response.get(0).getFrom());
         assertEquals("EUR", response.get(0).getTo());
         assertEquals(0.81281, response.get(0).getPrice(), 0.00001);
@@ -60,7 +61,7 @@ class CurrencyExchangeServiceTest {
                 .setBody("bad request"));
 
         Exception e = assertThrows(CurrencyExchangeServiceError.class, () -> {
-            currencyExchangeService.getExchangeRate("USD", "EUR");
+            client.getAllExchangeRates();
         });
         assertEquals("CurrencyExchangeServiceError Client error: bad request", e.getMessage());
     }
@@ -71,8 +72,9 @@ class CurrencyExchangeServiceTest {
                 .setResponseCode(500)
                 .setBody("The server is down, sorry!"));
         Exception e = assertThrows(CurrencyExchangeServiceError.class, () -> {
-            currencyExchangeService.getExchangeRate("USD", "EUR");
+            client.getAllExchangeRates();
         });
         assertEquals("CurrencyExchangeServiceError Server error: The server is down, sorry!", e.getMessage());
     }
+
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,3 @@
 currency.exchange.service.uri=http://localhost:8081
 currency.exchange.service.token=10dc303535874aeccc86a8251e6992f5
-currency.exchange.service.cache.evictionTime=240000
+currency.exchange.service.cache.evictionTime=1000

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+currencies=("AUD" "CAD" "CHF" "EUR" "GBP" "JPY" "NZD" "SGD" "USD")
+for i in {1..10000}
+do
+  rand1=${currencies[$RANDOM % ${#currencies[@]} ]}
+  rand2=${currencies[$RANDOM % ${#currencies[@]} ]}
+  echo "Attempt $i:"
+  curl http://localhost:8080/api/exchange-rates?fromCurrency=${rand1}\&toCurrency=${rand2}
+  echo " "
+done


### PR DESCRIPTION
CurrencyExchangeService needs to cache provider results to get around the API quota while maintaining the 5-minute freshness requirement and supporting 10,000 requests per day. 